### PR TITLE
Adds server start functionality to mocha api tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,7 +57,4 @@ app.use(function(err, req, res) {
   res.render(err);
 });
 
-app.listen(8000);
-console.log('listening on http://localhost:' + '8000');
-
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "data-miner": "./dataminer-cli.js"
   },
   "scripts": {
-    "start": "node app.js",
+    "start": "node server.js",
     "test": "./node_modules/mocha/bin/mocha --recursive '**/*spec.js'",
     "test-travis": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --recursive '**/*spec.js'",
     "test-watch": "./node_modules/mocha/bin/mocha --watch --recursive '**/*spec.js'",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const app = require('./app');
+
+let port = process.argv[1];
+
+app.listen(port || 8000);
+console.log('listening on http://localhost:' + port);

--- a/server.js
+++ b/server.js
@@ -2,7 +2,14 @@
 
 const app = require('./app');
 
+/*
 let port = process.argv[1];
+
+app.listen(port || 8000);
+console.log('listening on http://localhost:' + port);
+*/
+
+let port = 8000;
 
 app.listen(port || 8000);
 console.log('listening on http://localhost:' + port);

--- a/test/api-controller/data-spec.js
+++ b/test/api-controller/data-spec.js
@@ -5,21 +5,23 @@ var expect = chai.expect;
 var testData = require('../utils/test-jira-data.json');
 const fixtures = require('../utils/test-fixtures.json');
 var request = require('sync-request');
+let app = require('../../app');
 
 describe('API tests', function () {
 
-  const baseUrl = 'http://localhost:8000';
+  const baseUrl = 'http://127.0.0.1:8000';
   const sprint = fixtures.sprintName;
   const issue = fixtures.sampleIssues[1];
   const start = fixtures.startDate;
   const end = fixtures.endDate;
 
-  beforeEach(function () {
-    //
+  before(function (done) {
+    app.listen(8000);
+    done();
   });
 
   afterEach(function () {
-    //
+    app.close();
   });
 
   it('/data/burndown should return successfully on good data', function () {

--- a/test/api-controller/data-spec.js
+++ b/test/api-controller/data-spec.js
@@ -16,12 +16,12 @@ describe('API tests', function () {
   const end = fixtures.endDate;
 
   before(function (done) {
-    app.listen(8000);
-    done();
+    //var server = require('../../server');
+    app.listen(8000, done);
   });
 
-  afterEach(function () {
-    app.close();
+  afterEach(function (done) {
+    app.close(done);
   });
 
   it('/data/burndown should return successfully on good data', function () {
@@ -241,11 +241,12 @@ describe('API tests', function () {
     expect(res.statusCode).to.equal(200);
   });
 
-  it('/data/resolvedDates should return unsuccessfully when no jira data passed', function () {
+  it('/data/resolvedDates should return unsuccessfully when no jira data passed', function (done) {
     var obj = {};
     var res = request('POST', baseUrl + '/data/resolvedDates', { json: obj });
 
     expect(res.statusCode).to.equal(500);
+    done();
   });
 
 });


### PR DESCRIPTION
Build failing as api tests rely on server being started manually, otherwise they all fail.

PR seeks to automate starting of server when api tests are run

Currently WIP